### PR TITLE
Link directly to live site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ The Creeper API for IP addresses is at http://gnuheter.com/creeper/jsonip
 
 Also using the Wikimedia Tool Labs API: http://tools.wmflabs.org/
 
-Intended for use at http://gnuheter.com/creeper/
+Intended for use at http://gnuheter.com/creeper/wikipedia
 
 Based on Angular and Bootstrap. Feel free to help with making it better.


### PR DESCRIPTION
gnuheter.com/creeper leads to an about page, gnuheter.com/creeper/wikipedia is the live site. I'd also suggest adding a direct link to the live application in the "official" URL field next to the description in the GitHub repo. (Skriver på engelska för att ge det hela en internationell air.)
